### PR TITLE
Updates DB name to match Code Snippet example

### DIFF
--- a/knpu/ep3-doctrine/install.md
+++ b/knpu/ep3-doctrine/install.md
@@ -59,7 +59,7 @@ added a new `DATABASE_URL` environment variable:
 [[[ code('3d6b07ba40') ]]]
 
 Let's set this up: I use a `root` user with no password locally. Call the database
-`the_spacebar`:
+`symfony4_space_bar`:
 
 [[[ code('b119a2078e') ]]]
 


### PR DESCRIPTION
Upon following through with the tutorial i quickly realised that the ``DB`` name on the lesson notes doesn't correspond to the Code Snippet provided. 
I just update the lesson notes to reflect whats on the Snippet. :smile: 