### PR TITLE
Fix markdown misprint: ``prod`` -> `prod`

### DIFF
--- a/sfcasts/upgrade-sf5/prod-vault.md
+++ b/sfcasts/upgrade-sf5/prod-vault.md
@@ -127,7 +127,7 @@ Then, find your console and clear the cache:
 php bin/console cache:clear
 ```
 
-I don't need to add `--env=prod` *now* because we are *already* in the ``prod``
+I don't need to add `--env=prod` *now* because we are *already* in the `prod`
 environment thanks to the `APP_ENV` change.
 
 Ok, go try it! Refresh and... yes! That's the value from the `prod` vault! Symfony


### PR DESCRIPTION
https://symfonycasts.com/screencast/symfony5-upgrade/prod-vault

![chrome_Tloh46Gdqx](https://user-images.githubusercontent.com/29716703/76338814-87074200-62f9-11ea-831c-34a1c8554a14.png)
