### PR TITLE
Fix markdown misprint: [[[[ code() -> [[[ code()

### DIFF
--- a/sfcasts/upgrade-sf5/migrate-password-hashing.md
+++ b/sfcasts/upgrade-sf5/migrate-password-hashing.md
@@ -14,7 +14,7 @@ Anyways, what's *actually* stored on this field is a "hash" or kind of "fingerpr
 of the plaintext password and there are multiple hashing algorithms available.
 The one *you're* using is configured in `config/packages/security.yaml`:
 
-[[[[ code('b91b201db8') ]]]]
+[[[ code('b91b201db8') ]]]
 
 The `encoders` section says that whenever we encode, or really, "hash" a password -
 like when someone registers or when they log in - the `bcrypt` algorithm will be


### PR DESCRIPTION
[https://symfonycasts.com/screencast/symfony5-upgrade/migrate-password-hashing#hashing-algorithms-over-time](https://symfonycasts.com/screencast/symfony5-upgrade/migrate-password-hashing#hashing-algorithms-over-time)

![screenshot](https://user-images.githubusercontent.com/29716703/76619063-50643e00-652a-11ea-993e-d4db74353a71.PNG)
